### PR TITLE
Add font awesome icons to Brief component

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,16 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
     "jest": "^22.4.3",
+    "less-loader": "^4.1.0",
     "style-loader": "^0.20.3",
     "webpack": "^4.5.0",
     "webpack-cli": "^2.0.14",
     "webpack-dev-server": "^3.1.3"
   },
   "dependencies": {
+    "@fortawesome/fontawesome": "^1.1.5",
+    "@fortawesome/fontawesome-free-solid": "^5.0.10",
+    "@fortawesome/react-fontawesome": "0.0.18",
     "axios": "^0.18.0",
     "body-parser": "^1.18.2",
     "eslint": "^4.19.1",
@@ -49,6 +53,7 @@
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.3.1",
     "react-flexbox-grid": "^2.0.0",
+    "react-fontawesome": "^1.6.1",
     "semantic-ui-react": "^0.79.1"
   }
 }

--- a/src/components/Brief.jsx
+++ b/src/components/Brief.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import styles from '/Users/devops/Desktop/Hacking/Projects/Interstellarbnb/stylesheets/brief-style.css';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faUsers from '@fortawesome/fontawesome-free-solid/faUsers';
+import faBed from '@fortawesome/fontawesome-free-solid/faBed';
+import faBath from '@fortawesome/fontawesome-free-solid/faBath';
+import faHome from '@fortawesome/fontawesome-free-solid/faHome';
 
 const Brief = (props) => {
   return (
@@ -9,17 +14,17 @@ const Brief = (props) => {
       <div className={styles.location}>{props.info.location}</div>
       <div className="box">
         <div className={styles.stats}>
-          <div className="guests">{props.info.numGuests} Guests</div>
+          <div className="guests"><FontAwesomeIcon icon={faUsers} /> {props.info.numGuests} Guests</div>
         </div>
         <div className={styles.stats}>
-          <div className="bedrooms">{props.info.numBedrooms} Bedroom</div>
+          <div className="bedrooms"><FontAwesomeIcon icon={faHome} /> {props.info.numBedrooms} Bedroom</div>
         </div>
       </div>
       <div className={styles.stats}>
-        <div className="beds">{props.info.numBeds} Beds</div>
+        <div className="beds"><FontAwesomeIcon icon={faBed} /> {props.info.numBeds} Beds</div>
       </div>
       <div className={styles.stats}>
-        <div className="baths">{props.info.numBaths} Bath</div>
+        <div className="baths"><FontAwesomeIcon icon={faBath} /> {props.info.numBaths} Bath</div>
       </div>
     </div>
   );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,8 @@ module.exports = {
           limit: 10000,
         },
       },
+      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
+      { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'file-loader' },
     ],
   },
   resolve: {


### PR DESCRIPTION
Added Font Awesome, adjusted webpack loaders, and imported specific icons from FA library. If i make the Amenities component, I'll consider creating another file just for importing FA icons as to clean up all the import statements. Each icon is loaded individually to avoid loading entire icon library. 